### PR TITLE
Add NTP Safeguards

### DIFF
--- a/owoow.Core/Connection/ConnectionWrapper.cs
+++ b/owoow.Core/Connection/ConnectionWrapper.cs
@@ -318,7 +318,7 @@ public class ConnectionWrapperAsync(SwitchConnectionConfig Config, Action<string
         await Connection.SendAsync(Click(X, CRLF), token).ConfigureAwait(false);
         await Task.Delay(1_000, token).ConfigureAwait(false);
         await Connection.SendAsync(Click(A, CRLF), token).ConfigureAwait(false);
-        await Task.Delay(5_000 + config.ExtraTimeCloseGame, token);
+        await Task.Delay(5_000 + config.ExtraTimeCloseGame, token).ConfigureAwait(false);
     }
 
     // From https://github.com/kwsch/SysBot.NET/blob/8a82453e96ed5724e175b1a44464c70eca266df0/SysBot.Pokemon/SWSH/PokeRoutineExecutor8SWSH.cs#L233

--- a/owoow.WinForms/MainWindow.cs
+++ b/owoow.WinForms/MainWindow.cs
@@ -293,11 +293,11 @@ public partial class MainWindow : Form
                 {
                     this.DisplayMessageBox(ex.Message);
                 }
-                await Source.CancelAsync();
+                await Source.CancelAsync().ConfigureAwait(false);
                 Source = new();
-                await AdvanceSource.CancelAsync();
+                await AdvanceSource.CancelAsync().ConfigureAwait(false);
                 AdvanceSource = new();
-                await ResetSource.CancelAsync();
+                await ResetSource.CancelAsync().ConfigureAwait(false);
                 ResetSource = new();
                 SetControlEnabledState(true, B_Connect);
             },
@@ -312,7 +312,7 @@ public partial class MainWindow : Form
             {
                 try
                 {
-                    await ConnectionWrapper.ResetTimeNTP(Source.Token);
+                    await ConnectionWrapper.ResetTimeNTP(Source.Token).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -373,7 +373,7 @@ public partial class MainWindow : Form
 
                         SetButtonText($"{i + 1}", B_SkipAdvance);
                         await ConnectionWrapper.PressL3(AdvanceSource.Token).ConfigureAwait(false);
-                        await Task.Delay(150, AdvanceSource.Token);
+                        await Task.Delay(150, AdvanceSource.Token).ConfigureAwait(false);
                     }
                     SetButtonText("Adv.", B_SkipAdvance);
                     SetControlEnabledState(true, B_SkipAdvance, B_SkipForward, B_SkipBack, B_Turbo, B_SeedSearch);
@@ -400,7 +400,7 @@ public partial class MainWindow : Form
         ResetSource = new();
         try
         {
-            if (ConnectionWrapper is { Connected: true }) await ConnectionWrapper.ResetStick(AdvanceSource.Token);
+            if (ConnectionWrapper is { Connected: true }) await ConnectionWrapper.ResetStick(AdvanceSource.Token).ConfigureAwait(false);
         }
         catch { }
     }
@@ -421,11 +421,11 @@ public partial class MainWindow : Form
                         if (i % 366 == 0)
                         {
                             await ConnectionWrapper.ResetTimeNTP(AdvanceSource.Token).ConfigureAwait(false);
-                            await Task.Delay(200, AdvanceSource.Token);
+                            await Task.Delay(200, AdvanceSource.Token).ConfigureAwait(false);
                         }
                         SetButtonText($"{i + 1}", B_SkipForward);
                         await ConnectionWrapper.DaySkip(AdvanceSource.Token).ConfigureAwait(false);
-                        await Task.Delay(360, AdvanceSource.Token);
+                        await Task.Delay(360, AdvanceSource.Token).ConfigureAwait(false);
                     }
                     SetButtonText("Days+", B_SkipForward);
                     SetControlEnabledState(true, B_SkipAdvance, B_SkipForward, B_SkipBack, B_Turbo, B_SeedSearch);
@@ -457,7 +457,7 @@ public partial class MainWindow : Form
                     {
                         SetButtonText($"{i + 1}", B_SkipBack);
                         await ConnectionWrapper.DaySkipBack(AdvanceSource.Token).ConfigureAwait(false);
-                        await Task.Delay(360, AdvanceSource.Token);
+                        await Task.Delay(360, AdvanceSource.Token).ConfigureAwait(false);
                     }
                     SetButtonText("Days-", B_SkipBack);
                     SetControlEnabledState(true, B_SkipAdvance, B_SkipForward, B_SkipBack, B_Turbo, B_SeedSearch);
@@ -571,7 +571,7 @@ public partial class MainWindow : Form
 
         Task.Run(async () =>
         {
-            results = await Task.WhenAll(tasks);
+            results = await Task.WhenAll(tasks).ConfigureAwait(false);
             List<OverworldFrame> AllResults = [];
             foreach (var result in results)
             {
@@ -685,7 +685,7 @@ public partial class MainWindow : Form
 
         Task.Run(async () =>
         {
-            results = await Task.WhenAll(tasks);
+            results = await Task.WhenAll(tasks).ConfigureAwait(false);
             List<OverworldFrame> AllResults = [];
             foreach (var result in results)
             {
@@ -789,7 +789,7 @@ public partial class MainWindow : Form
 
         Task.Run(async () =>
         {
-            results = await Task.WhenAll(tasks);
+            results = await Task.WhenAll(tasks).ConfigureAwait(false);
             List<OverworldFrame> AllResults = [];
             foreach (var result in results)
             {
@@ -904,7 +904,7 @@ public partial class MainWindow : Form
 
         Task.Run(async () =>
         {
-            results = await Task.WhenAll(tasks);
+            results = await Task.WhenAll(tasks).ConfigureAwait(false);
             List<OverworldFrame> AllResults = [];
             foreach (var result in results)
             {
@@ -1174,7 +1174,7 @@ public partial class MainWindow : Form
 
                             await Task.Run(async () =>
                             {
-                                results = await Task.WhenAll(tasks);
+                                results = await Task.WhenAll(tasks).ConfigureAwait(false);
                                 List<OverworldFrame> AllResults = [];
                                 foreach (var result in results)
                                 {
@@ -1433,7 +1433,7 @@ public partial class MainWindow : Form
                     {
                         ulong s0 = ulong.Parse(TB_Seed0.Text, NumberStyles.AllowHexSpecifier);
                         ulong s1 = ulong.Parse(TB_Seed1.Text, NumberStyles.AllowHexSpecifier);
-                        await ConnectionWrapper.WriteRNGState(s0, s1, Source.Token);
+                        await ConnectionWrapper.WriteRNGState(s0, s1, Source.Token).ConfigureAwait(false);
                         reset = true;
                     }
                     catch (Exception ex)
@@ -1571,7 +1571,7 @@ public partial class MainWindow : Form
                 try
                 {
                     readPause = true;
-                    await Task.Delay(100, Source.Token);
+                    await Task.Delay(100, Source.Token).ConfigureAwait(false);
 
                     var DexRec = await ConnectionWrapper.ReadDexRecommendation(Source.Token).ConfigureAwait(false);
 
@@ -1648,9 +1648,9 @@ public partial class MainWindow : Form
                     try
                     {
                         readPause = true;
-                        await Task.Delay(100, Source.Token);
+                        await Task.Delay(100, Source.Token).ConfigureAwait(false);
                         SetTextBoxText("Reading encounter...", TB_Wild);
-                        var pk = await ConnectionWrapper.ReadWildPokemon(Source.Token);
+                        var pk = await ConnectionWrapper.ReadWildPokemon(Source.Token).ConfigureAwait(false);
                         if (pk.Valid && pk.Species > 0)
                         {
                             CachedEncounter = pk;

--- a/owoow.WinForms/MainWindow.cs
+++ b/owoow.WinForms/MainWindow.cs
@@ -412,7 +412,7 @@ public partial class MainWindow : Form
             {
                 try
                 {
-                    SetControlEnabledState(false, B_SkipAdvance, B_SkipForward, B_SkipBack, B_Turbo, B_SeedSearch);
+                    SetControlEnabledState(false, B_SkipAdvance, B_SkipForward, B_SkipBack, B_Turbo, B_SeedSearch, B_NTP);
                     SetControlEnabledState(true, B_CancelSkip);
                     skipPause = false;
                     var skips = uint.Parse(TB_Skips.Text);
@@ -449,7 +449,7 @@ public partial class MainWindow : Form
             {
                 try
                 {
-                    SetControlEnabledState(false, B_SkipAdvance, B_SkipForward, B_SkipBack, B_Turbo, B_SeedSearch);
+                    SetControlEnabledState(false, B_SkipAdvance, B_SkipForward, B_SkipBack, B_Turbo, B_SeedSearch, B_NTP);
                     SetControlEnabledState(true, B_CancelSkip);
                     skipPause = false;
                     var skips = uint.Parse(TB_Skips.Text);

--- a/owoow.WinForms/MainWindow.cs
+++ b/owoow.WinForms/MainWindow.cs
@@ -435,14 +435,16 @@ public partial class MainWindow : Form
             }
             catch (Exception ex)
             {
-                this.DisplayMessageBox($"Error during ResetTimeNTP: {ex.Message}");
+                this.DisplayMessageBox($"Error during ResetTimeNTP: {ex.Message}\nPlease report this error.");
             }
             finally
             {
                 lock (resetTimeNTPLock)
                 {
                     canCallResetTimeNTP = true;
-                    SetControlEnabledState(true, B_NTP);
+                    // Only enable the NTP button if the skip advance button is enabled, which means we're not currently skipping.
+                    if (B_SkipAdvance.Enabled)
+                        SetControlEnabledState(true, B_NTP);
                 }
             }
         });
@@ -471,11 +473,17 @@ public partial class MainWindow : Form
                     }
                     SetButtonText("Days+", B_SkipForward);
                     SetControlEnabledState(true, B_SkipAdvance, B_SkipForward, B_SkipBack, B_Turbo, B_SeedSearch);
+                    // Only reset the NTP button if it's not on cooldown.
+                    if (canCallResetTimeNTP)
+                        SetControlEnabledState(true, B_NTP);
                     SetControlEnabledState(false, B_CancelSkip);
                 }
                 catch (Exception ex)
                 {
                     SetControlEnabledState(true, B_SkipAdvance, B_SkipForward, B_SkipBack, B_Turbo, B_SeedSearch);
+                    // Only reset the NTP button if it's not on cooldown.
+                    if (canCallResetTimeNTP)
+                        SetControlEnabledState(true, B_NTP);
                     SetControlEnabledState(false, B_CancelSkip);
                     SetButtonText("Days+", B_SkipForward);
                     if (ex is not OperationCanceledException) this.DisplayMessageBox(ex.Message);
@@ -503,11 +511,17 @@ public partial class MainWindow : Form
                     }
                     SetButtonText("Days-", B_SkipBack);
                     SetControlEnabledState(true, B_SkipAdvance, B_SkipForward, B_SkipBack, B_Turbo, B_SeedSearch);
+                    // Only reset the NTP button if it's not on cooldown.
+                    if (canCallResetTimeNTP)
+                        SetControlEnabledState(true, B_NTP);
                     SetControlEnabledState(false, B_CancelSkip);
                 }
                 catch (Exception ex)
                 {
                     SetControlEnabledState(true, B_SkipAdvance, B_SkipForward, B_SkipBack, B_Turbo, B_SeedSearch);
+                    // Only reset the NTP button if it's not on cooldown.
+                    if (canCallResetTimeNTP)
+                        SetControlEnabledState(true, B_NTP);
                     SetControlEnabledState(false, B_CancelSkip);
                     SetButtonText("Days-", B_SkipBack);
                     if (ex is not OperationCanceledException) this.DisplayMessageBox(ex.Message);

--- a/owoow.WinForms/MainWindow.cs
+++ b/owoow.WinForms/MainWindow.cs
@@ -455,11 +455,6 @@ public partial class MainWindow : Form
                     var skips = uint.Parse(TB_Skips.Text);
                     for (var i = 0; i < skips && !skipPause; i++)
                     {
-                        if (i % 366 == 0)
-                        {
-                            await ConnectionWrapper.ResetTimeNTP(AdvanceSource.Token).ConfigureAwait(false);
-                            await Task.Delay(200, AdvanceSource.Token);
-                        }
                         SetButtonText($"{i + 1}", B_SkipBack);
                         await ConnectionWrapper.DaySkipBack(AdvanceSource.Token).ConfigureAwait(false);
                         await Task.Delay(360, AdvanceSource.Token);

--- a/owoow.WinForms/MainWindow.cs
+++ b/owoow.WinForms/MainWindow.cs
@@ -370,7 +370,6 @@ public partial class MainWindow : Form
                     var skips = uint.Parse(TB_Skips.Text);
                     for (var i = 0; i < skips && !skipPause; i++)
                     {
-
                         SetButtonText($"{i + 1}", B_SkipAdvance);
                         await ConnectionWrapper.PressL3(AdvanceSource.Token).ConfigureAwait(false);
                         await Task.Delay(150, AdvanceSource.Token).ConfigureAwait(false);
@@ -465,12 +464,17 @@ public partial class MainWindow : Form
                     for (var i = 0; i < skips && !skipPause; i++)
                     {
                         // Attempt to reset the time every 366 skips if NTP isn't on cooldown.
-                        if (i > 0 && i % 366 == 0)
+                        // If we're less than 366 from the end, then wait until then to NTP.
+                        if (i > 0 && i % 366 == 0 && skips - i > 366)
                             await SafeResetTimeNTP(AdvanceSource.Token).ConfigureAwait(false);
                         SetButtonText($"{i + 1}", B_SkipForward);
                         await ConnectionWrapper.DaySkip(AdvanceSource.Token).ConfigureAwait(false);
                         await Task.Delay(360, AdvanceSource.Token).ConfigureAwait(false);
                     }
+
+                    // Will only NTP if not on cooldown.
+                    await SafeResetTimeNTP(AdvanceSource.Token).ConfigureAwait(false);
+
                     SetButtonText("Days+", B_SkipForward);
                     SetControlEnabledState(true, B_SkipAdvance, B_SkipForward, B_SkipBack, B_Turbo, B_SeedSearch);
                     // Only reset the NTP button if it's not on cooldown.

--- a/owoow.WinForms/MainWindow.cs
+++ b/owoow.WinForms/MainWindow.cs
@@ -445,7 +445,8 @@ public partial class MainWindow : Form
                     SetControlEnabledState(true, B_NTP);
                 }
             }
-        }, token);
+        });
+        await Task.Delay(200, AdvanceSource.Token).ConfigureAwait(false);
     }
 
     private void B_SkipForward_Click(object sender, EventArgs e)
@@ -461,11 +462,9 @@ public partial class MainWindow : Form
                     var skips = uint.Parse(TB_Skips.Text);
                     for (var i = 0; i < skips && !skipPause; i++)
                     {
-                        if (i % 366 == 0)
-                        {
+                        // Attempt to reset the time every 366 skips if NTP isn't on cooldown.
+                        if (i > 0 && i % 366 == 0)
                             await SafeResetTimeNTP(AdvanceSource.Token).ConfigureAwait(false);
-                            await Task.Delay(200, AdvanceSource.Token).ConfigureAwait(false);
-                        }
                         SetButtonText($"{i + 1}", B_SkipForward);
                         await ConnectionWrapper.DaySkip(AdvanceSource.Token).ConfigureAwait(false);
                         await Task.Delay(360, AdvanceSource.Token).ConfigureAwait(false);

--- a/owoow.WinForms/Subforms/Cram-o-matic.cs
+++ b/owoow.WinForms/Subforms/Cram-o-matic.cs
@@ -77,7 +77,7 @@ public partial class Cramomatic : Form
 
         Task.Run(async () =>
         {
-            Frames = await Task.Run(async () => await Core.RNG.Generators.Item.Cramomatic.Generate(s0, s1, initial, initial + advances, config));
+            Frames = await Task.Run(async () => await Core.RNG.Generators.Item.Cramomatic.Generate(s0, s1, initial, initial + advances, config).ConfigureAwait(false));
 
             MainWindow.SetBindingSourceDataSource(Frames, CramomaticResultsSource);
 

--- a/owoow.WinForms/Subforms/DiggingPa.cs
+++ b/owoow.WinForms/Subforms/DiggingPa.cs
@@ -69,7 +69,7 @@ public partial class DiggingPa : Form
 
         Task.Run(async () =>
         {
-            Frames = await Task.Run(async () => await Core.RNG.Generators.Item.DiggingPa.Generate(s0, s1, initial, initial + advances, config));
+            Frames = await Task.Run(async () => await Core.RNG.Generators.Item.DiggingPa.Generate(s0, s1, initial, initial + advances, config).ConfigureAwait(false));
 
             MainWindow.SetBindingSourceDataSource(Frames, DiggingPaResultsSource);
 

--- a/owoow.WinForms/Subforms/Loto-ID.cs
+++ b/owoow.WinForms/Subforms/Loto-ID.cs
@@ -87,7 +87,7 @@ public partial class LotoID : Form
 
         Task.Run(async () =>
         {
-            Frames = await Task.Run(async () => await Core.RNG.Generators.Item.LotoID.Generate(s0, s1, initial, initial + advances, config));
+            Frames = await Task.Run(async () => await Core.RNG.Generators.Item.LotoID.Generate(s0, s1, initial, initial + advances, config).ConfigureAwait(false));
 
             MainWindow.SetBindingSourceDataSource(Frames, LotoIDResultsSource);
 

--- a/owoow.WinForms/Subforms/MenuCloseTimeline.cs
+++ b/owoow.WinForms/Subforms/MenuCloseTimeline.cs
@@ -65,7 +65,7 @@ public partial class MenuCloseTimeline : Form
 
         Task.Run(async () =>
         {
-            List<MenuCloseFrame> results = await Task.Run(async () => await MenuClose.Generate(s0, s1, initial, initial + advances, config));
+            List<MenuCloseFrame> results = await Task.Run(async () => await MenuClose.Generate(s0, s1, initial, initial + advances, config).ConfigureAwait(false));
 
             MainWindow.SetBindingSourceDataSource(results, MenuCloseResultsSource);
 

--- a/owoow.WinForms/Subforms/SpreadFinder.cs
+++ b/owoow.WinForms/Subforms/SpreadFinder.cs
@@ -107,7 +107,7 @@ public partial class SpreadFinder : Form
 
         Task.Run(async () =>
         {
-            results = await Task.WhenAll(tasks);
+            results = await Task.WhenAll(tasks).ConfigureAwait(false);
             List<SpreadFinderFrame> AllResults = [];
             foreach (var result in results)
             {

--- a/owoow.WinForms/Subforms/WailordRespawn.cs
+++ b/owoow.WinForms/Subforms/WailordRespawn.cs
@@ -70,7 +70,7 @@ public partial class WailordRespawn : Form
 
         Task.Run(async () =>
         {
-            Frames = await Task.Run(async () => await Wailord.Generate(s0, s1, initial, initial + advances, config));
+            Frames = await Task.Run(async () => await Wailord.Generate(s0, s1, initial, initial + advances, config).ConfigureAwait(false));
 
             MainWindow.SetBindingSourceDataSource(Frames, WailordResultsSource);
 

--- a/owoow.WinForms/Subforms/WattTrader.cs
+++ b/owoow.WinForms/Subforms/WattTrader.cs
@@ -72,7 +72,7 @@ public partial class WattTrader : Form
 
         Task.Run(async () =>
         {
-            Frames = await Task.Run(async () => await Core.RNG.Generators.Item.WattTrader.Generate(s0, s1, initial, initial + advances, config));
+            Frames = await Task.Run(async () => await Core.RNG.Generators.Item.WattTrader.Generate(s0, s1, initial, initial + advances, config).ConfigureAwait(false));
 
             MainWindow.SetBindingSourceDataSource(Frames, WattTraderResultsSource);
 


### PR DESCRIPTION
Querying the NTP server too often was causing the program to set the system date to 0, which displayed as Dec 31, 1999. This pull request fixes the issue in several ways:

1. Added a cooldown for NTP so it's only possible to perform every 2 seconds, whether during automatic date skipping or by manually pressing the NTP button.
2. NTP was being called at the start of date skipping when `i == 0`. This has been modified so that it will only call on multiples of 366, unless we are less than 366 from the end. Date skipping forward now attempts to NTP at the end.
3. The NTP button is dimmed during cooldown and when date skipping.
4. The NTP button is only undimmed if there is no cooldown and there is no date skipping.

This fix requires modifications to the custom botbase to not set the system time if it's invalid: https://github.com/LegoFigure11/usb-botbase/pull/1.

One side effect is that NTP may not always occur at the end of date skipping due to being on cooldown.

Additionally added some missing `ConfigureAwait(false)`.

This should close https://github.com/LegoFigure11/owoow/issues/7.