### PR TITLE
Removes unnecessary button presses from OpenGame

### DIFF
--- a/owoow.Core/Connection/ConnectionWrapper.cs
+++ b/owoow.Core/Connection/ConnectionWrapper.cs
@@ -337,13 +337,6 @@ public class ConnectionWrapperAsync(SwitchConnectionConfig Config, Action<string
             await Task.Delay(1_000 + config.ExtraTimeLoadProfile, token).ConfigureAwait(false);
         }
 
-        StatusUpdate("Checking DLC...");
-        await Connection.SendAsync(Click(A, CRLF), token).ConfigureAwait(false);
-        await Task.Delay(1_000 + config.ExtraTimeCheckDLC, token).ConfigureAwait(false);
-
-        StatusUpdate("Opening the game...");
-        await Connection.SendAsync(Click(DUP, CRLF), token).ConfigureAwait(false);
-        await Task.Delay(0_600, token).ConfigureAwait(false);
         await Connection.SendAsync(Click(A, CRLF), token).ConfigureAwait(false);
         await Task.Delay(0_600, token).ConfigureAwait(false);
 


### PR DESCRIPTION
Switch update 20.0.1 introduces the game sharing feature, which removes the extra check for profiles/DLC.