### PR TITLE
Switch Y and Z in Pokemon coordinates to match player coordinates

### DIFF
--- a/owoow.Core/Connection/ConnectionWrapper.cs
+++ b/owoow.Core/Connection/ConnectionWrapper.cs
@@ -5,7 +5,6 @@ using SysBot.Base;
 using System.Net.Sockets;
 using static SysBot.Base.SwitchButton;
 using static SysBot.Base.SwitchCommand;
-using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace owoow.Core.Connection;
 

--- a/owoow.Core/Structures/OverworldPokemon.cs
+++ b/owoow.Core/Structures/OverworldPokemon.cs
@@ -13,8 +13,8 @@ public class OverworldPokemon(byte[] data, MyStatus8 myStatus)
     private ushort SID => myStatus.SID16;
 
     public float X => ReadSingleLittleEndian(Data.AsSpan()[..]);
-    public float Y => ReadSingleLittleEndian(Data.AsSpan()[0x04..]);
-    public float Z => ReadSingleLittleEndian(Data.AsSpan()[0x08..]);
+    public float Y => ReadSingleLittleEndian(Data.AsSpan()[0x08..]);
+    public float Z => ReadSingleLittleEndian(Data.AsSpan()[0x04..]);
 
     public PK8 PK8 => GeneratePK8();
 
@@ -43,7 +43,7 @@ public class OverworldPokemon(byte[] data, MyStatus8 myStatus)
             Gender = (byte)(Gender == 1 ? 0 : 1),
             TID16 = TID,
             SID16 = SID,
-            Version = (GameVersion)44,
+            Version = GameVersion.SW,
         };
 
         pk8.SetNature((Nature)Nature);


### PR DESCRIPTION
Player coordinates are configured such that the first two values indicate X and Y on the flat map, and the last value is a Z for height off of the map. The games generally order them as X, Z, Y so the Pokémon coordinates have to be rearranged to match.