### PR TITLE
Fix Static Encounter Table Inaccuracies

### DIFF
--- a/owoow.Core/Resources/Shield/sh_static.json
+++ b/owoow.Core/Resources/Shield/sh_static.json
@@ -18863,7 +18863,7 @@
           "IsAbilityLocked": false,
           "Ability": 0,
           "IsShinyLocked": false,
-          "GuaranteedIVs": 0
+          "GuaranteedIVs": 3
         },
         "3": {
           "Species": "Wailord",
@@ -18927,7 +18927,7 @@
           "IsAbilityLocked": false,
           "Ability": 0,
           "IsShinyLocked": false,
-          "GuaranteedIVs": 0
+          "GuaranteedIVs": 3
         },
         "3": {
           "Species": "Wailord",
@@ -18963,7 +18963,7 @@
           "IsAbilityLocked": false,
           "Ability": 0,
           "IsShinyLocked": false,
-          "GuaranteedIVs": 0
+          "GuaranteedIVs": 3
         },
         "3": {
           "Species": "Wailord",
@@ -18999,7 +18999,7 @@
           "IsAbilityLocked": false,
           "Ability": 0,
           "IsShinyLocked": false,
-          "GuaranteedIVs": 0
+          "GuaranteedIVs": 3
         },
         "3": {
           "Species": "Wailord",
@@ -19087,7 +19087,7 @@
           "IsAbilityLocked": false,
           "Ability": 0,
           "IsShinyLocked": false,
-          "GuaranteedIVs": 0
+          "GuaranteedIVs": 3
         },
         "3": {
           "Species": "Wailord",

--- a/owoow.Core/Resources/Shield/sh_static.json
+++ b/owoow.Core/Resources/Shield/sh_static.json
@@ -597,7 +597,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -641,7 +641,7 @@
     "Overcast": {
       "Encounters": {
         "0": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -693,7 +693,7 @@
     "Raining": {
       "Encounters": {
         "0": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -753,7 +753,7 @@
     "Thunderstorm": {
       "Encounters": {
         "0": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -805,7 +805,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -857,7 +857,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -909,7 +909,7 @@
     "Snowstorm": {
       "Encounters": {
         "0": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -961,7 +961,7 @@
     "Sandstorm": {
       "Encounters": {
         "0": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -1021,7 +1021,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -7587,7 +7587,7 @@
           "GuaranteedIVs": 0
         },
         "9": {
-          "Species": "Keldeo",
+          "Species": "Keldeo-1",
           "Level": 65,
           "IsAbilityLocked": true,
           "Ability": 0,
@@ -7695,11 +7695,11 @@
           "GuaranteedIVs": 0
         },
         "6": {
-          "Species": "Keldeo",
+          "Species": "Keldeo-1",
           "Level": 65,
           "IsAbilityLocked": true,
           "Ability": 0,
-          "IsShinyLocked": false,
+          "IsShinyLocked": true,
           "GuaranteedIVs": 3
         },
         "7": {
@@ -7851,11 +7851,11 @@
           "GuaranteedIVs": 0
         },
         "11": {
-          "Species": "Keldeo",
+          "Species": "Keldeo-1",
           "Level": 65,
           "IsAbilityLocked": true,
           "Ability": 0,
-          "IsShinyLocked": false,
+          "IsShinyLocked": true,
           "GuaranteedIVs": 3
         },
         "12": {
@@ -8015,11 +8015,11 @@
           "GuaranteedIVs": 0
         },
         "13": {
-          "Species": "Keldeo",
+          "Species": "Keldeo-1",
           "Level": 65,
           "IsAbilityLocked": true,
           "Ability": 0,
-          "IsShinyLocked": false,
+          "IsShinyLocked": true,
           "GuaranteedIVs": 3
         },
         "14": {
@@ -8123,11 +8123,11 @@
           "GuaranteedIVs": 0
         },
         "7": {
-          "Species": "Keldeo",
+          "Species": "Keldeo-1",
           "Level": 65,
           "IsAbilityLocked": true,
           "Ability": 0,
-          "IsShinyLocked": false,
+          "IsShinyLocked": true,
           "GuaranteedIVs": 3
         },
         "8": {
@@ -8263,11 +8263,11 @@
           "GuaranteedIVs": 0
         },
         "9": {
-          "Species": "Keldeo",
+          "Species": "Keldeo-1",
           "Level": 65,
           "IsAbilityLocked": true,
           "Ability": 0,
-          "IsShinyLocked": false,
+          "IsShinyLocked": true,
           "GuaranteedIVs": 3
         },
         "10": {
@@ -8439,11 +8439,11 @@
           "GuaranteedIVs": 0
         },
         "10": {
-          "Species": "Keldeo",
+          "Species": "Keldeo-1",
           "Level": 65,
           "IsAbilityLocked": true,
           "Ability": 0,
-          "IsShinyLocked": false,
+          "IsShinyLocked": true,
           "GuaranteedIVs": 3
         },
         "11": {
@@ -11314,7 +11314,7 @@
           "GuaranteedIVs": 0
         },
         "2": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -11398,7 +11398,7 @@
           "GuaranteedIVs": 0
         },
         "2": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -11482,7 +11482,7 @@
           "GuaranteedIVs": 0
         },
         "2": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -11558,7 +11558,7 @@
           "GuaranteedIVs": 0
         },
         "2": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -11626,7 +11626,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -11710,7 +11710,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -11794,7 +11794,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -11886,7 +11886,7 @@
           "GuaranteedIVs": 0
         },
         "2": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -11970,7 +11970,7 @@
           "GuaranteedIVs": 0
         },
         "2": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -19112,7 +19112,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 50,
           "IsAbilityLocked": false,
           "Ability": 0,

--- a/owoow.Core/Resources/Shield/sh_static.json
+++ b/owoow.Core/Resources/Shield/sh_static.json
@@ -18872,6 +18872,46 @@
           "Ability": 0,
           "IsShinyLocked": false,
           "GuaranteedIVs": 0
+        },
+        "4": {
+          "Species": "Rotom-1",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "5": {
+          "Species": "Rotom-2",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "6": {
+          "Species": "Rotom-3",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "7": {
+          "Species": "Rotom-4",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "8": {
+          "Species": "Rotom-5",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
         }
       }
     },
@@ -18936,6 +18976,46 @@
           "Ability": 0,
           "IsShinyLocked": false,
           "GuaranteedIVs": 0
+        },
+        "4": {
+          "Species": "Rotom-1",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "5": {
+          "Species": "Rotom-2",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "6": {
+          "Species": "Rotom-3",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "7": {
+          "Species": "Rotom-4",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "8": {
+          "Species": "Rotom-5",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
         }
       }
     },
@@ -18972,6 +19052,46 @@
           "Ability": 0,
           "IsShinyLocked": false,
           "GuaranteedIVs": 0
+        },
+        "4": {
+          "Species": "Rotom-1",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "5": {
+          "Species": "Rotom-2",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "6": {
+          "Species": "Rotom-3",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "7": {
+          "Species": "Rotom-4",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "8": {
+          "Species": "Rotom-5",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
         }
       }
     },
@@ -19004,6 +19124,46 @@
         "3": {
           "Species": "Wailord",
           "Level": 80,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "4": {
+          "Species": "Rotom-1",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "5": {
+          "Species": "Rotom-2",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "6": {
+          "Species": "Rotom-3",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "7": {
+          "Species": "Rotom-4",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "8": {
+          "Species": "Rotom-5",
+          "Level": 50,
           "IsAbilityLocked": false,
           "Ability": 0,
           "IsShinyLocked": false,
@@ -19056,6 +19216,46 @@
         "2": {
           "Species": "Wailord",
           "Level": 80,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "4": {
+          "Species": "Rotom-1",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "5": {
+          "Species": "Rotom-2",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "6": {
+          "Species": "Rotom-3",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "7": {
+          "Species": "Rotom-4",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "8": {
+          "Species": "Rotom-5",
+          "Level": 50,
           "IsAbilityLocked": false,
           "Ability": 0,
           "IsShinyLocked": false,

--- a/owoow.Core/Resources/Sword/sw_static.json
+++ b/owoow.Core/Resources/Sword/sw_static.json
@@ -19025,7 +19025,7 @@
           "IsAbilityLocked": false,
           "Ability": 0,
           "IsShinyLocked": false,
-          "GuaranteedIVs": 0
+          "GuaranteedIVs": 3
         },
         "3": {
           "Species": "Wailord",
@@ -19089,7 +19089,7 @@
           "IsAbilityLocked": false,
           "Ability": 0,
           "IsShinyLocked": false,
-          "GuaranteedIVs": 0
+          "GuaranteedIVs": 3
         },
         "3": {
           "Species": "Wailord",
@@ -19125,7 +19125,7 @@
           "IsAbilityLocked": false,
           "Ability": 0,
           "IsShinyLocked": false,
-          "GuaranteedIVs": 0
+          "GuaranteedIVs": 3
         },
         "3": {
           "Species": "Wailord",
@@ -19161,7 +19161,7 @@
           "IsAbilityLocked": false,
           "Ability": 0,
           "IsShinyLocked": false,
-          "GuaranteedIVs": 0
+          "GuaranteedIVs": 3
         },
         "3": {
           "Species": "Wailord",
@@ -19249,7 +19249,7 @@
           "IsAbilityLocked": false,
           "Ability": 0,
           "IsShinyLocked": false,
-          "GuaranteedIVs": 0
+          "GuaranteedIVs": 3
         },
         "3": {
           "Species": "Wailord",

--- a/owoow.Core/Resources/Sword/sw_static.json
+++ b/owoow.Core/Resources/Sword/sw_static.json
@@ -597,7 +597,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -641,7 +641,7 @@
     "Overcast": {
       "Encounters": {
         "0": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -693,7 +693,7 @@
     "Raining": {
       "Encounters": {
         "0": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -753,7 +753,7 @@
     "Thunderstorm": {
       "Encounters": {
         "0": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -805,7 +805,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -857,7 +857,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -909,7 +909,7 @@
     "Snowstorm": {
       "Encounters": {
         "0": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -961,7 +961,7 @@
     "Sandstorm": {
       "Encounters": {
         "0": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -1021,7 +1021,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -7547,7 +7547,7 @@
           "GuaranteedIVs": 0
         },
         "9": {
-          "Species": "Keldeo",
+          "Species": "Keldeo-1",
           "Level": 65,
           "IsAbilityLocked": true,
           "Ability": 0,
@@ -7655,11 +7655,11 @@
           "GuaranteedIVs": 0
         },
         "6": {
-          "Species": "Keldeo",
+          "Species": "Keldeo-1",
           "Level": 65,
           "IsAbilityLocked": true,
           "Ability": 0,
-          "IsShinyLocked": false,
+          "IsShinyLocked": true,
           "GuaranteedIVs": 3
         },
         "7": {
@@ -7811,11 +7811,11 @@
           "GuaranteedIVs": 0
         },
         "11": {
-          "Species": "Keldeo",
+          "Species": "Keldeo-1",
           "Level": 65,
           "IsAbilityLocked": true,
           "Ability": 0,
-          "IsShinyLocked": false,
+          "IsShinyLocked": true,
           "GuaranteedIVs": 3
         },
         "12": {
@@ -7975,11 +7975,11 @@
           "GuaranteedIVs": 0
         },
         "13": {
-          "Species": "Keldeo",
+          "Species": "Keldeo-1",
           "Level": 65,
           "IsAbilityLocked": true,
           "Ability": 0,
-          "IsShinyLocked": false,
+          "IsShinyLocked": true,
           "GuaranteedIVs": 3
         },
         "14": {
@@ -8083,11 +8083,11 @@
           "GuaranteedIVs": 0
         },
         "7": {
-          "Species": "Keldeo",
+          "Species": "Keldeo-1",
           "Level": 65,
           "IsAbilityLocked": true,
           "Ability": 0,
-          "IsShinyLocked": false,
+          "IsShinyLocked": true,
           "GuaranteedIVs": 3
         },
         "8": {
@@ -8223,11 +8223,11 @@
           "GuaranteedIVs": 0
         },
         "9": {
-          "Species": "Keldeo",
+          "Species": "Keldeo-1",
           "Level": 65,
           "IsAbilityLocked": true,
           "Ability": 0,
-          "IsShinyLocked": false,
+          "IsShinyLocked": true,
           "GuaranteedIVs": 3
         },
         "10": {
@@ -8399,11 +8399,11 @@
           "GuaranteedIVs": 0
         },
         "10": {
-          "Species": "Keldeo",
+          "Species": "Keldeo-1",
           "Level": 65,
           "IsAbilityLocked": true,
           "Ability": 0,
-          "IsShinyLocked": false,
+          "IsShinyLocked": true,
           "GuaranteedIVs": 3
         },
         "11": {
@@ -11444,7 +11444,7 @@
           "GuaranteedIVs": 0
         },
         "2": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -11528,7 +11528,7 @@
           "GuaranteedIVs": 0
         },
         "2": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -11612,7 +11612,7 @@
           "GuaranteedIVs": 0
         },
         "2": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -11688,7 +11688,7 @@
           "GuaranteedIVs": 0
         },
         "2": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -11756,7 +11756,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -11840,7 +11840,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -11924,7 +11924,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -12016,7 +12016,7 @@
           "GuaranteedIVs": 0
         },
         "2": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -12100,7 +12100,7 @@
           "GuaranteedIVs": 0
         },
         "2": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 56,
           "IsAbilityLocked": false,
           "Ability": 0,
@@ -19274,7 +19274,7 @@
           "GuaranteedIVs": 0
         },
         "1": {
-          "Species": "Gastrodon",
+          "Species": "Gastrodon-1",
           "Level": 50,
           "IsAbilityLocked": false,
           "Ability": 0,

--- a/owoow.Core/Resources/Sword/sw_static.json
+++ b/owoow.Core/Resources/Sword/sw_static.json
@@ -19034,6 +19034,46 @@
           "Ability": 0,
           "IsShinyLocked": false,
           "GuaranteedIVs": 0
+        },
+        "4": {
+          "Species": "Rotom-1",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "5": {
+          "Species": "Rotom-2",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "6": {
+          "Species": "Rotom-3",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "7": {
+          "Species": "Rotom-4",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "8": {
+          "Species": "Rotom-5",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
         }
       }
     },
@@ -19098,6 +19138,46 @@
           "Ability": 0,
           "IsShinyLocked": false,
           "GuaranteedIVs": 0
+        },
+        "4": {
+          "Species": "Rotom-1",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "5": {
+          "Species": "Rotom-2",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "6": {
+          "Species": "Rotom-3",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "7": {
+          "Species": "Rotom-4",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "8": {
+          "Species": "Rotom-5",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
         }
       }
     },
@@ -19134,6 +19214,46 @@
           "Ability": 0,
           "IsShinyLocked": false,
           "GuaranteedIVs": 0
+        },
+        "4": {
+          "Species": "Rotom-1",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "5": {
+          "Species": "Rotom-2",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "6": {
+          "Species": "Rotom-3",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "7": {
+          "Species": "Rotom-4",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "8": {
+          "Species": "Rotom-5",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
         }
       }
     },
@@ -19166,6 +19286,46 @@
         "3": {
           "Species": "Wailord",
           "Level": 80,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "4": {
+          "Species": "Rotom-1",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "5": {
+          "Species": "Rotom-2",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "6": {
+          "Species": "Rotom-3",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "7": {
+          "Species": "Rotom-4",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "8": {
+          "Species": "Rotom-5",
+          "Level": 50,
           "IsAbilityLocked": false,
           "Ability": 0,
           "IsShinyLocked": false,
@@ -19254,6 +19414,46 @@
         "3": {
           "Species": "Wailord",
           "Level": 80,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "4": {
+          "Species": "Rotom-1",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "5": {
+          "Species": "Rotom-2",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "6": {
+          "Species": "Rotom-3",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "7": {
+          "Species": "Rotom-4",
+          "Level": 50,
+          "IsAbilityLocked": false,
+          "Ability": 0,
+          "IsShinyLocked": false,
+          "GuaranteedIVs": 0
+        },
+        "8": {
+          "Species": "Rotom-5",
+          "Level": 50,
           "IsAbilityLocked": false,
           "Ability": 0,
           "IsShinyLocked": false,


### PR DESCRIPTION
I believe the Rotom encounter in Workout Sea should have 3 guaranteed IVs, currently listed as 0. Let me know if there are any mistakes to correct.

Thanks to TheOfficialSquishy for bringing this to attention.